### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/tools/security/simple_github_security.py
+++ b/tools/security/simple_github_security.py
@@ -221,7 +221,7 @@ class SimpleGitHubSecurityLoader:
         )
         # Note: Secret scanning alerts are available but not displayed for security reasons
         print(f"   - Dependabot Alerts: {security_data['summary']['total_dependabot_alerts']}")
-        # NOTE: Vulnerability alerts count not logged to avoid exposing sensitive detail
+        # NOTE: Vulnerability alerts count not logged to avoid exposing sensitive details
         # print(f"   - Vulnerability Alerts: {security_data['summary']['total_vulnerability_alerts']}")
 
 

--- a/tools/security/simple_github_security.py
+++ b/tools/security/simple_github_security.py
@@ -221,9 +221,9 @@ class SimpleGitHubSecurityLoader:
         )
         # Note: Secret scanning alerts are available but not displayed for security reasons
         print(f"   - Dependabot Alerts: {security_data['summary']['total_dependabot_alerts']}")
-        print(
-            f"   - Vulnerability Alerts: {security_data['summary']['total_vulnerability_alerts']}"
-        )
+        # NOTE: Vulnerability alerts count not logged to avoid exposing sensitive detail
+        # print(f"   - Vulnerability Alerts: {security_data['summary']['total_vulnerability_alerts']}")
+
 
         return security_data
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoAir/security/code-scanning/5](https://github.com/Dino-Pit-Studios/DinoAir/security/code-scanning/5)

Sensitive information—including counts or indicators that secrets have been discovered through scanning—should not be logged as clear text. In the identified code, the `print` statement on line 225 outputs the number of vulnerability alerts, which may be derived from secret scanning results and thus be sensitive. To address this:

- Remove or redact the log output corresponding to the total vulnerability alerts.
- Optionally, replace the log message with a generic statement, such as "Vulnerability alerts present" (without stating the count), or simply omit printing this line altogether.
- Only touch the regions of code directly responsible for logging the value (line 225 in `get_all_security_data` method) and avoid any unnecessary changes.

No additional imports or method definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
