### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/tools/security/simple_github_security.py
+++ b/tools/security/simple_github_security.py
@@ -216,9 +216,9 @@ class SimpleGitHubSecurityLoader:
 
         # Print summary
         print("\n📊 Security Summary:")
-        print(
-            f"   - Code Scanning Alerts: {security_data['summary']['total_code_scanning_alerts']}"
-        )
+        # Do NOT log code scanning alert counts, as even counts can be sensitive.
+        # print(f"   - Code Scanning Alerts: {security_data['summary']['total_code_scanning_alerts']}")
+        
         # Note: Secret scanning alerts are available but not displayed for security reasons
         # print(f"   - Dependabot Alerts: {security_data['summary']['total_dependabot_alerts']}")
         # NOTE: Vulnerability alerts count not logged to avoid exposing sensitive details

--- a/tools/security/simple_github_security.py
+++ b/tools/security/simple_github_security.py
@@ -218,7 +218,7 @@ class SimpleGitHubSecurityLoader:
         print("\n📊 Security Summary:")
         # Do NOT log code scanning alert counts, as even counts can be sensitive.
         # print(f"   - Code Scanning Alerts: {security_data['summary']['total_code_scanning_alerts']}")
-        
+
         # Note: Secret scanning alerts are available but not displayed for security reasons
         # print(f"   - Dependabot Alerts: {security_data['summary']['total_dependabot_alerts']}")
         # NOTE: Vulnerability alerts count not logged to avoid exposing sensitive details


### PR DESCRIPTION
Potential fix for [https://github.com/Dino-Pit-Studios/DinoAir/security/code-scanning/3](https://github.com/Dino-Pit-Studios/DinoAir/security/code-scanning/3)

The best way to fix this issue is to remove or redact the log entry that exposes the count of code scanning alerts (`total_code_scanning_alerts`). To fix it:
- In the method `get_all_security_data`, remove or comment out the log line that prints the code scanning alerts count (line 220).
- Ensure that the summary information is still returned in the returned object, but it is not logged.
- Add a comment to clarify why you are not logging potentially sensitive alert counts, for maintainers' future reference.

No changes to imports or the method's functionality are needed other than removing/commenting the line(s) that print sensitive(alert)-related counts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
